### PR TITLE
Add support for RSZ numbers without a month defined

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,10 +10,10 @@
   "license": "MIT",
   "require-dev": {
     "phing/phing": "^2.0.0",
-    "phpunit/phpunit": "^6.0.0"
+    "phpunit/phpunit": "^8.0.0"
   },
   "require": {
-    "php": ">=7.1.0",
+    "php": "^7.2",
     "ext-mbstring": "*",
     "setbased/exception": "^1.0.0"
   },

--- a/src/Rijksregisternummer.php
+++ b/src/Rijksregisternummer.php
@@ -58,12 +58,12 @@ class Rijksregisternummer
   /**
    * Returns the birthday of this identification number of the National Register.
    *
-   * @return string
+   * @return string|null
    *
    * @since 1.0.0
    * @api
    */
-  public function getBirthday(): string
+  public function getBirthday(): ?string
   {
     return RijksregisternummerHelper::getBirthday($this->rijksregisternummer);
   }

--- a/src/RijksregisternummerHelper.php
+++ b/src/RijksregisternummerHelper.php
@@ -111,12 +111,12 @@ class RijksregisternummerHelper
    *
    * @param string $rijksregisternummer The clean and valid identification number of the National Register.
    *
-   * @return string
+   * @return string|null
    *
    * @since 1.0.0
    * @api
    */
-  public static function getBirthday(string $rijksregisternummer): string
+  public static function getBirthday(string $rijksregisternummer): ?string
   {
     // Extract the birthday and sequence parts.
     $part1 = substr($rijksregisternummer, 0, 9);
@@ -129,6 +129,11 @@ class RijksregisternummerHelper
     $year  = (($born1900) ? '19' : '20').substr($rijksregisternummer, 0, 2);
     $month = (int)substr($rijksregisternummer, 2, 2);
     $day   = (int)substr($rijksregisternummer, 4, 2);
+
+    if (empty($month))
+    {
+      return null;
+    }
 
     $month = self::readjustMonth($month);
 
@@ -257,11 +262,14 @@ class RijksregisternummerHelper
     $month = (int)substr($rijksregisternummer, 2, 2);
     $day   = (int)substr($rijksregisternummer, 4, 2);
 
-    $month = self::readjustMonth($month);
-
-    if (!checkdate($month, $day, $year))
+    if (!empty($month))
     {
-      return false;
+      $month = self::readjustMonth($month);
+
+      if (!checkdate($month, $day, $year))
+      {
+        return false;
+      }
     }
 
     // Test counter. The counter must between 1 and 998.

--- a/test/RijksregisternummerTest.php
+++ b/test/RijksregisternummerTest.php
@@ -76,6 +76,17 @@ class RijksregisternummerTest extends TestCase
 
   //--------------------------------------------------------------------------------------------------------------------
   /**
+   * Tests for humanFormat.
+   */
+  public function testValidWithoutBirthday()
+  {
+    $rijksregisternummer = new Rijksregisternummer('65.00.03-131.77');
+    self::assertSame('65.00.03-131.77', $rijksregisternummer->humanFormat());
+    self::assertNull($rijksregisternummer->getBirthday());
+  }
+
+  //--------------------------------------------------------------------------------------------------------------------
+  /**
    * Test with an invalid rijksregisternummer (invalid check).
    *
    * @expectedException \UnexpectedValueException


### PR DESCRIPTION
We have a case where an worker that just got there identity card, doesn't have a known birthday. The RSZ number is valid in this case, but we're unable to check the birthday with this.

This presents an FallenException with month = 0.

Edge case but this number should be marked as valid. Can provide a copy of the ID card if required via a secure way to validate this number.